### PR TITLE
🛡️ Sentinel: [HIGH] Enable Content Security Policy headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - Enable nuxt-security CSP
+**Vulnerability:** nuxt-security is installed and its `contentSecurityPolicy` is set to false in `nuxt.config.ts` by default.
+**Learning:** This removes CSP header entirely instead of making it strictly secure.
+**Prevention:** We should remove the `contentSecurityPolicy: false` line from `nuxt.config.ts` so that `nuxt-security` applies its default secure CSP headers.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -219,10 +219,8 @@ export default defineNuxtConfig({
     },
   },
 
-  // Nuxt Security module configuration to disable the default Content Security Policy
   security: {
     headers: {
-      contentSecurityPolicy: false,
     },
   },
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `nuxt-security` module had its `contentSecurityPolicy` explicitly disabled (`false`) in `nuxt.config.ts`. This left the application without a fundamental defense layer against XSS and data injection attacks.
🎯 Impact: Without a Content Security Policy, an attacker could potentially execute malicious scripts or load unauthorized resources if another vulnerability (like XSS) exists in the application.
🔧 Fix: Removed `contentSecurityPolicy: false` to allow the `nuxt-security` module to apply its secure default CSP headers, adhering to the principle of defense in depth. Also cleaned up the misleading comment regarding disabling the CSP.
✅ Verification: The application builds successfully and the `nuxt.config.ts` no longer contains the insecure setting.

---
*PR created automatically by Jules for task [17589180319990935633](https://jules.google.com/task/17589180319990935633) started by @BleckWolf25*

## Summary by Sourcery

Re-enable the default Content Security Policy headers provided by nuxt-security and document the security learning in the Sentinel records.

Enhancements:
- Remove the explicit disabling of nuxt-security's Content Security Policy so default secure headers are applied.

Documentation:
- Add a Sentinel markdown entry documenting the CSP misconfiguration, its impact, and the chosen remediation.