### PR TITLE
🔒 Fix overly permissive CORS configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,7 +100,7 @@ export default defineNuxtConfig({
     '/favicon.ico': { headers: { 'cache-control': 'public, max-age=86400' } },
 
     // API responses caching if applicable
-    '/api/**': { cors: true, headers: { 'cache-control': 'max-age=60' } },
+    '/api/**': { headers: { 'access-control-allow-origin': 'https://joaoccosta.vercel.app', 'cache-control': 'max-age=60' } },
   },
 
   // Nuxt modules


### PR DESCRIPTION
🎯 **What:** The CORS configuration for `/api/**` was set to `cors: true` which implicitly injected wildcard (`*`) headers, allowing any origin to access the API. This has been updated to explicitly specify the required domain via `headers`.

⚠️ **Risk:** Allowing any origin to fetch API data could enable malicious sites to query or leverage user sessions to hit internal APIs (though this is a static site, adopting strict security hygiene is important). 

🛡️ **Solution:** Replaced `cors: true` with a specifically targeted `access-control-allow-origin` header that only permits `https://joaoccosta.vercel.app` (the production domain). Local development will continue functioning fine due to same-origin bypassing CORS enforcement automatically.

---
*PR created automatically by Jules for task [17384454699572598399](https://jules.google.com/task/17384454699572598399) started by @BleckWolf25*

## Summary by Sourcery

Enhancements:
- Configure API route CORS headers to only allow https://joaoccosta.vercel.app while preserving existing cache-control settings.