### PR TITLE
🧪 Add SpecialisationCard unit tests

### DIFF
--- a/tests/unit/components/ui/SpecialisationCard.test.ts
+++ b/tests/unit/components/ui/SpecialisationCard.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @file SpecialisationCard.test.ts
+ *
+ * @version 1.0.0
+ * @author Bleckwolf25
+ * @license MIT
+ *
+ * @summary Property-based tests for the SpecialisationCard UI component.
+ *
+ * @description
+ * Property-based tests for the SpecialisationCard UI component. Covers:
+ * - Property 1: No `<img>` elements or inline background-image styles are rendered
+ * - Property 8: All required fields (title, description) are visible
+ * All tests use `fast-check` to generate arbitrary properties.
+ *
+ * @since 02/06/2026
+ * @updated 02/06/2026
+ */
+// ---------- IMPORTS
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import * as fc from 'fast-check'
+import SpecialisationCard from '../../../../app/components/ui/SpecialisationCard.vue'
+
+// ---------- HELPERS
+const globalOptions = {
+  stubs: {
+    UIcon: true,
+  },
+}
+
+const nonEmptyString = fc.string({ minLength: 1 }).filter((s) => /^\S+$/.test(s))
+
+// ---------- TESTS
+describe('SpecialisationCard', () => {
+  it('renders no images (Property 1)', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          title: nonEmptyString,
+          description: nonEmptyString,
+          icon: nonEmptyString,
+        }),
+        (props) => {
+          const wrapper = mount(SpecialisationCard, { props, global: globalOptions })
+          expect(wrapper.findAll('img').length).toBe(0)
+
+          const elementsWithBgImage = wrapper.findAll('*').filter((w) => {
+            const el = w.element as HTMLElement
+            return !!el.style?.backgroundImage
+          })
+          expect(elementsWithBgImage.length).toBe(0)
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  it('renders all required fields', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          title: nonEmptyString,
+          description: nonEmptyString,
+          icon: nonEmptyString,
+        }),
+        (props) => {
+          const wrapper = mount(SpecialisationCard, { props, global: globalOptions })
+          expect(wrapper.text()).toContain(props.title)
+          expect(wrapper.text()).toContain(props.description)
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `SpecialisationCard` UI component.
📊 **Coverage:** Ensures that the component safely renders text (title and description) correctly and doesn't output `<img>` elements or background images. Tested via property-based testing across multiple random inputs.
✨ **Result:** Test coverage for `app/components/ui/SpecialisationCard.vue` has increased, solidifying the test suite.

---
*PR created automatically by Jules for task [6800237644063286935](https://jules.google.com/task/6800237644063286935) started by @BleckWolf25*

## Summary by Sourcery

Add property-based unit tests for the SpecialisationCard UI component to validate its rendering behavior.

Tests:
- Introduce fast-check based tests to ensure SpecialisationCard never renders <img> tags or inline background images across random inputs.
- Verify that SpecialisationCard consistently displays the provided title and description across randomized props.