### PR TITLE
🧹 [Code Health] Remove unused console.log in build smoke test

### DIFF
--- a/tests/smoke/build.test.ts
+++ b/tests/smoke/build.test.ts
@@ -37,10 +37,6 @@ describe('Build outputs', () => {
     // Check only if the directory exists (to prevent dev-time failures)
     if (targetPath) {
       expect(fs.existsSync(path.join(targetPath, 'index.html'))).toBe(true)
-    } else {
-      console.log(
-        'Skipping build test because neither .output/public nor .vercel/output/static exists yet.'
-      )
     }
   })
 })


### PR DESCRIPTION
🎯 **What:** Removed unused `console.log` from `tests/smoke/build.test.ts`
💡 **Why:** Cleans up the test output and improves readability, removing unnecessary and unhelpful log lines during local development and testing
✅ **Verification:** Verified that `pnpm test tests/smoke/build.test.ts` continues to pass, and the code logic remains unchanged.
✨ **Result:** Improved code health and test suite cleanliness.

---
*PR created automatically by Jules for task [15379616620680383559](https://jules.google.com/task/15379616620680383559) started by @BleckWolf25*

## Summary by Sourcery

Enhancements:
- Remove unused console.log from the build smoke test to reduce noisy test output.