### PR TITLE
🧹 chore: Remove unused Ref import from AppNavbar

### DIFF
--- a/app/components/AppNavbar.vue
+++ b/app/components/AppNavbar.vue
@@ -151,7 +151,8 @@
  * @updated 02/06/2026
  */
 // ---------- IMPORTS
-import { ref, computed, type Ref } from 'vue'
+
+import { ref, computed } from 'vue'
 import { useScrollSpy } from '~/composables/useScrollSpy'
 import { useI18n } from '#imports'
 


### PR DESCRIPTION
🎯 **What:** Removed unused `type Ref` import from `app/components/AppNavbar.vue`.
💡 **Why:** Cleans up the code and reduces unused imports, improving readability.
✅ **Verification:** Ran `pnpm test` successfully (all tests pass, including AppNavbar component tests) and `eslint app/components/AppNavbar.vue` to verify linting. 
✨ **Result:** A slightly cleaner AppNavbar component without altering functionality.

---
*PR created automatically by Jules for task [15411056093476890494](https://jules.google.com/task/15411056093476890494) started by @BleckWolf25*

## Summary by Sourcery

Chores:
- Remove unused Ref type import from the AppNavbar Vue component to reduce dead code.